### PR TITLE
support for multipart data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 
+    implementation 'com.github.mizosoft.methanol:methanol:1.7.0'
+
     implementation 'io.vertx:vertx-web-client:4.5.7'
     implementation 'io.vertx:vertx-core:4.5.7'
 

--- a/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
+++ b/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
@@ -2,6 +2,7 @@ package com.javadiscord.jdi.internal.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.mizosoft.methanol.MultipartBodyPublisher;
 
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
@@ -54,6 +55,12 @@ public class DiscordRequestBuilder {
 
     public DiscordRequestBuilder body(HttpRequest.BodyPublisher body) {
         this.body = body;
+        return this;
+    }
+
+    public DiscordRequestBuilder multipartBody(MultipartBodyPublisher body) {
+        this.body = body;
+        this.headers.put("Content-Type", "multipart/form-data");
         return this;
     }
 

--- a/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
+++ b/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
@@ -52,6 +52,11 @@ public class DiscordRequestBuilder {
         return this;
     }
 
+    public DiscordRequestBuilder body(HttpRequest.BodyPublisher body) {
+        this.body = body;
+        return this;
+    }
+
     public DiscordRequestBuilder get() {
         this.method = HttpMethod.GET;
         return this;


### PR DESCRIPTION
**Describe the PR**
This PR adds the [Methanol](https://mizosoft.github.io/methanol/) library so that we are able to handle multipart data. You can refer to [this](https://mizosoft.github.io/methanol/multipart_and_forms/) to see how to utilize it, but for the most part instead of passing a `Map<String, Object>` into the body method on a `DiscordRequestBuilder` it will take in a `HttpRequest.BodyPublisher` which you get from using the `MultipartBodyPublisher` class.

**Things to discuss before PR is merged**:
- [x] Should the request have to specify the header for multipart data or should we bake it into the `body(HttpRequest.BodyPublisher)` method?