### PR TITLE
fix: adds branching logic to deserialize guildId as String or long

### DIFF
--- a/core/src/main/java/com/javadiscord/jdi/core/GatewayEventListener.java
+++ b/core/src/main/java/com/javadiscord/jdi/core/GatewayEventListener.java
@@ -41,7 +41,14 @@ public class GatewayEventListener implements GatewayObserver {
         try {
             Field guildIdField = event.getClass().getDeclaredField("guildId");
             guildIdField.setAccessible(true);
-            long guildId = (long) guildIdField.get(event);
+            long guildId;
+
+            if (guildIdField.getType() == String.class) {
+                guildId = Long.parseLong((String) guildIdField.get(event));
+            } else {
+                guildId = (long) guildIdField.get(event);
+            }
+
             com.javadiscord.jdi.core.models.guild.Guild model =
                     (com.javadiscord.jdi.core.models.guild.Guild)
                             cache.getCacheForGuild(guildId)


### PR DESCRIPTION
**Describe the PR**
adds branching logic to deserialize guildId as String or long
fix for bug described in issue [104](https://github.com/javadiscord/java-discord-api/issues/104)