### PR TITLE
Change default body to `HttpRequest.BodyPublishers.noBody()`

### DIFF
--- a/api/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
+++ b/api/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestBuilder.java
@@ -17,7 +17,7 @@ public class DiscordRequestBuilder {
     private final Map<String, Object> queryParameters = new HashMap<>();
     private HttpMethod method;
     private String path;
-    private HttpRequest.BodyPublisher body;
+    private HttpRequest.BodyPublisher body = HttpRequest.BodyPublishers.noBody();
 
     public DiscordRequestBuilder putHeader(String name, Object value) {
         this.headers.put(name, value);


### PR DESCRIPTION
# About
resolves #107 

Changes the default body from `null` to `HttpRequest.BodyPublishers.noBody()` to prevent `NullPointerException`.