### PR TITLE
Fixes bugs in `DiscordResponseParser`

### DIFF
--- a/api/src/main/java/com/javadiscord/jdi/core/api/AuditLogsRequest.java
+++ b/api/src/main/java/com/javadiscord/jdi/core/api/AuditLogsRequest.java
@@ -15,7 +15,7 @@ public class AuditLogsRequest {
     }
 
     public AsyncResponse<List<AuditLogEntry>> getAuditLogs(GetAuditLogsBuilder builder) {
-        return responseParser.callAndParseList(
-                AuditLogEntry.class, builder.guildId(guildId).build());
+        return responseParser.callAndParseMap(
+                "audit_log_entries", builder.guildId(guildId).build());
     }
 }

--- a/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
+++ b/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
@@ -22,16 +22,16 @@ public class DiscordResponseParser {
         AsyncResponse<List<T>> asyncResponse = new AsyncResponse<>();
         DiscordResponseFuture future = dispatcher.queue(request);
         future.onSuccess(
-                res -> {
-                    if (res.status() >= 200 && res.status() < 300) {
+                response -> {
+                    if (isSuccessfulResponse(response)) {
                         try {
-                            List<T> resultList = parseResponseFromList(clazz, res.body());
+                            List<T> resultList = parseResponseFromList(clazz, response.body());
                             asyncResponse.setResult(resultList);
                         } catch (Exception e) {
                             asyncResponse.setException(e);
                         }
                     } else {
-                        asyncResponse.setException(errorResponseException(res));
+                        asyncResponse.setException(errorResponseException(response));
                     }
                 });
         future.onError(asyncResponse::setException);
@@ -42,16 +42,16 @@ public class DiscordResponseParser {
         AsyncResponse<List<T>> asyncResponse = new AsyncResponse<>();
         DiscordResponseFuture future = dispatcher.queue(request);
         future.onSuccess(
-                res -> {
-                    if (res.status() >= 200 && res.status() < 300) {
+                response -> {
+                    if (isSuccessfulResponse(response)) {
                         try {
-                            List<T> resultList = parseResponseFromMap(key, res.body());
+                            List<T> resultList = parseResponseFromMap(key, response.body());
                             asyncResponse.setResult(resultList);
                         } catch (Exception e) {
                             asyncResponse.setException(e);
                         }
                     } else {
-                        asyncResponse.setException(errorResponseException(res));
+                        asyncResponse.setException(errorResponseException(response));
                     }
                 });
         future.onError(asyncResponse::setException);
@@ -87,7 +87,7 @@ public class DiscordResponseParser {
 
     private <T> void success(
             Class<T> type, DiscordResponse response, AsyncResponse<T> asyncResponse) {
-        if (response.status() >= 200 && response.status() < 300) {
+        if (isSuccessfulResponse(response)) {
             try {
                 T result = OBJECT_MAPPER.readValue(response.body(), type);
                 asyncResponse.setResult(result);
@@ -97,6 +97,10 @@ public class DiscordResponseParser {
         } else {
             asyncResponse.setException(errorResponseException(response));
         }
+    }
+
+    private boolean isSuccessfulResponse(DiscordResponse response) {
+        return response.status() >= 200 && response.status() < 300;
     }
 
     private Throwable errorResponseException(DiscordResponse response) {

--- a/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
+++ b/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
@@ -23,11 +23,15 @@ public class DiscordResponseParser {
         DiscordResponseFuture future = dispatcher.queue(request);
         future.onSuccess(
                 res -> {
-                    try {
-                        List<T> resultList = parseResponseFromList(clazz, res.body());
-                        asyncResponse.setResult(resultList);
-                    } catch (Exception e) {
-                        asyncResponse.setException(e);
+                    if (res.status() >= 200 && res.status() < 300) {
+                        try {
+                            List<T> resultList = parseResponseFromList(clazz, res.body());
+                            asyncResponse.setResult(resultList);
+                        } catch (Exception e) {
+                            asyncResponse.setException(e);
+                        }
+                    } else {
+                        asyncResponse.setException(errorResponseException(res));
                     }
                 });
         future.onError(asyncResponse::setException);
@@ -39,11 +43,15 @@ public class DiscordResponseParser {
         DiscordResponseFuture future = dispatcher.queue(request);
         future.onSuccess(
                 res -> {
-                    try {
-                        List<T> resultList = parseResponseFromMap(key, res.body());
-                        asyncResponse.setResult(resultList);
-                    } catch (Exception e) {
-                        asyncResponse.setException(e);
+                    if (res.status() >= 200 && res.status() < 300) {
+                        try {
+                            List<T> resultList = parseResponseFromMap(key, res.body());
+                            asyncResponse.setResult(resultList);
+                        } catch (Exception e) {
+                            asyncResponse.setException(e);
+                        }
+                    } else {
+                        asyncResponse.setException(errorResponseException(res));
                     }
                 });
         future.onError(asyncResponse::setException);
@@ -84,12 +92,15 @@ public class DiscordResponseParser {
                 asyncResponse.setException(e);
             }
         } else {
-            asyncResponse.setException(
-                    new Exception(
-                            "Received HTTP status code "
-                                    + response.status()
-                                    + " "
-                                    + response.body()));
+            asyncResponse.setException(errorResponseException(response));
         }
+    }
+
+    private Throwable errorResponseException(DiscordResponse response) {
+       return new Exception(
+                "Received HTTP status code "
+                        + response.status()
+                        + " "
+                        + response.body());
     }
 }

--- a/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
+++ b/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
@@ -68,9 +68,12 @@ public class DiscordResponseParser {
 
     private <T> List<T> parseResponseFromMap(String key, String response)
             throws JsonProcessingException {
-        Map<String, List<T>> res = OBJECT_MAPPER.readValue(
-                response,
-                OBJECT_MAPPER.getTypeFactory().constructMapType(Map.class, String.class, List.class));
+        Map<String, List<T>> res =
+                OBJECT_MAPPER.readValue(
+                        response,
+                        OBJECT_MAPPER
+                                .getTypeFactory()
+                                .constructMapType(Map.class, String.class, List.class));
         return res.get(key);
     }
 
@@ -97,10 +100,7 @@ public class DiscordResponseParser {
     }
 
     private Throwable errorResponseException(DiscordResponse response) {
-       return new Exception(
-                "Received HTTP status code "
-                        + response.status()
-                        + " "
-                        + response.body());
+        return new Exception(
+                "Received HTTP status code " + response.status() + " " + response.body());
     }
 }


### PR DESCRIPTION
**Describe the PR**
- Adds response parsing for map bodies
- Updates `AuditLogEntryRequest` to parse from map instead of list
- Fixes error handling for bad requests
- relates to issues [103](https://github.com/javadiscord/java-discord-api/issues/103) and [106](https://github.com/javadiscord/java-discord-api/issues/106)

