### PR TITLE
refactor(mapper): using objectmapper field

### DIFF
--- a/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
+++ b/api/src/main/java/com/javadiscord/jdi/core/api/DiscordResponseParser.java
@@ -35,10 +35,9 @@ public class DiscordResponseParser {
 
     private <T> List<T> parseResponse(Class<T> elementType, String response)
             throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(
+        return OBJECT_MAPPER.readValue(
                 response,
-                objectMapper.getTypeFactory().constructCollectionType(List.class, elementType));
+                OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, elementType));
     }
 
     public <T> AsyncResponse<T> callAndParse(Class<T> clazz, DiscordRequest request) {


### PR DESCRIPTION
This refactor resolves #105 by using field object mapper instead of additional created one.

**Checklist**
- [ ] This PR contains environment variables
- [ ] Documentation has been updated
- [ ] Tests have been added
- [ ] This PR contains breaking changes