### PR TITLE
Removed the automatic retry when discord closes the web socket

### DIFF
--- a/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketHandler.java
+++ b/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketHandler.java
@@ -82,8 +82,9 @@ public class WebSocketHandler implements Handler<WebSocket> {
     }
 
     private void handleClose(Void unused) {
-        retryHandler.retry(
-                () -> connectionMediator.getWebSocketManagerProxy().start(connectionMediator));
+        LOGGER.warn(
+                "The web socket connection to discord was closed. You will no longer receive"
+                        + " gateway events.");
     }
 
     void handleClose(int status, String reason) {
@@ -106,8 +107,13 @@ public class WebSocketHandler implements Handler<WebSocket> {
                         "Discord has updated their API, please use the latest updates on"
                                 + " https://javadiscord.com/");
                 break;
+            case GatewayCloseEventCode.DISALLOWED_INTENTS:
+                LOGGER.error(
+                        "You do not have all the required intents set on your bot. Visit"
+                                + " https://discord.com/developers/applications/");
+                break;
             default:
-                LOGGER.error("[{}] {}", status, reason);
+                LOGGER.error("Web socket close reason [{}] {}", status, reason);
                 break;
         }
     }


### PR DESCRIPTION
Closes #97

When discord actively closes the web socket connect we previously attempted to reconnect. This PR removes that because we can connect successfully but discord disconnects us straight away. 

We already have retrying in place were relevant so this should fix our issues. 