### PR TITLE
Fix stopping of service

### DIFF
--- a/api/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestDispatcher.java
+++ b/api/src/main/java/com/javadiscord/jdi/internal/api/DiscordRequestDispatcher.java
@@ -23,7 +23,7 @@ public class DiscordRequestDispatcher implements Runnable {
     private final HttpClient httpClient;
     private final BlockingQueue<DiscordRequestBuilder> queue;
     private final String botToken;
-    private AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean running = new AtomicBoolean(false);
     private int numberOfRequestsSent;
     private long timeSinceLastRequest;
 
@@ -45,6 +45,8 @@ public class DiscordRequestDispatcher implements Runnable {
     public void run() {
         running.set(true);
 
+        LOGGER.info("Request dispatcher has started");
+
         while (running.get()) {
             long currentTime = System.currentTimeMillis();
             long elapsed = currentTime - timeSinceLastRequest;
@@ -64,6 +66,8 @@ public class DiscordRequestDispatcher implements Runnable {
                 /* Ignore */
             }
         }
+
+        LOGGER.info("Request dispatcher has shutdown");
     }
 
     public void stop() {

--- a/core/src/main/java/com/javadiscord/jdi/core/Discord.java
+++ b/core/src/main/java/com/javadiscord/jdi/core/Discord.java
@@ -138,7 +138,7 @@ public class Discord {
     }
 
     public void start() {
-        this.webSocketManager =
+        webSocketManager =
             new WebSocketManager(
                 new GatewaySetting().setApiVersion(10).setEncoding(GatewayEncoding.JSON),
                 identifyRequest,
@@ -146,7 +146,7 @@ public class Discord {
             );
 
         WebSocketManagerProxy webSocketManagerProxy =
-            new WebSocketManagerProxy(this.webSocketManager);
+            new WebSocketManagerProxy(webSocketManager);
         ConnectionDetails connectionDetails =
             new ConnectionDetails(gateway.url(), botToken, gatewaySetting);
         ConnectionMediator connectionMediator =
@@ -159,13 +159,16 @@ public class Discord {
     }
 
     public void stop() {
-        if (this.webSocketManager != null) {
-            this.webSocketManager.stop();
+        LOGGER.info("Shutdown initiated");
+
+        if (webSocketManager != null) {
+            webSocketManager.stop();
         }
 
         discordRequestDispatcher.stop();
 
         EXECUTOR.shutdown();
+
         try {
             if (!EXECUTOR.awaitTermination(30, TimeUnit.SECONDS)) {
                 EXECUTOR.shutdownNow();
@@ -176,8 +179,8 @@ public class Discord {
                     );
                 }
             }
-        } catch (InterruptedException ie) {
-            LOGGER.error("Termination was interrupted within {} seconds.", 30);
+        } catch (InterruptedException e) {
+            LOGGER.error("Termination was interrupted within {} seconds", 30, e);
             Thread.currentThread().interrupt();
         }
     }

--- a/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketManager.java
+++ b/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketManager.java
@@ -106,8 +106,8 @@ public class WebSocketManager {
             .onFailure(err -> LOGGER.error("Failed to shutdown web socket client", err));
         retryAllowed = false;
         vertx.close()
-                .onSuccess(res -> LOGGER.info("Gateway has shutdown"))
-                .onFailure(err -> LOGGER.error("Failed to shutdown gateway", err));
+            .onSuccess(res -> LOGGER.info("Gateway has shutdown"))
+            .onFailure(err -> LOGGER.error("Failed to shutdown gateway", err));
     }
 
     public WebSocket getWebSocket() {

--- a/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketManager.java
+++ b/gateway/src/main/java/com/javadiscord/jdi/internal/gateway/WebSocketManager.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.http.WebSocketFrame;
 import org.apache.logging.log4j.LogManager;
@@ -21,6 +22,8 @@ public class WebSocketManager {
     private final WebSocketRetryHandler retryHandler;
     private final Cache cache;
     private WebSocket webSocket;
+    private WebSocketClient webSocketClient;
+    private boolean retryAllowed;
 
     public WebSocketManager(
         GatewaySetting gatewaySetting, IdentifyRequest identifyRequest, Cache cache
@@ -48,8 +51,9 @@ public class WebSocketManager {
                 )
                 .setSsl(true);
 
-        vertx.createWebSocketClient()
-            .connect(webSocketConnectOptions)
+        webSocketClient = vertx.createWebSocketClient();
+        retryAllowed = true;
+        webSocketClient.connect(webSocketConnectOptions)
             .onSuccess(
                 webSocket -> {
                     LOGGER.info("Connected to Discord");
@@ -74,7 +78,9 @@ public class WebSocketManager {
             .onFailure(
                 error -> {
                     LOGGER.warn("Failed to connect to {} {}", gatewayURL, error.getCause());
-                    retryHandler.retry(() -> restart(connectionMediator));
+                    if (retryAllowed) {
+                        retryHandler.retry(() -> restart(connectionMediator));
+                    }
                 }
             );
     }
@@ -86,14 +92,22 @@ public class WebSocketManager {
     }
 
     public void restart(ConnectionMediator connectionMediator) {
+        retryAllowed = true;
         stop();
         start(connectionMediator);
     }
 
     public void stop() {
-        if (!webSocket.isClosed()) {
+        if (webSocket != null && !webSocket.isClosed()) {
             webSocket.close();
         }
+        webSocketClient.close()
+            .onSuccess(res -> LOGGER.info("Web socket client has been shutdown"))
+            .onFailure(err -> LOGGER.error("Failed to shutdown web socket client", err));
+        retryAllowed = false;
+        vertx.close()
+                .onSuccess(res -> LOGGER.info("Gateway has shutdown"))
+                .onFailure(err -> LOGGER.error("Failed to shutdown gateway", err));
     }
 
     public WebSocket getWebSocket() {


### PR DESCRIPTION
The stop functionality introduced in #115 did not work correctly. During testing:

* it was not killing the gateway, the bot was still receiving and handling events
* the executor was failing to shutdown and there were loads of threads still running in the background
* the retry logic we have was re-initalizing the connection when the socket was disconnected

This PR implements the stop functionality properly and ensures all threads that were created have been killed.